### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     package="dk.nodes.filepicker">
 
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:remove="android:maxSdkVersion" />
 
     <application>
         <activity


### PR DESCRIPTION
Added a manifest merger check, so the WRITE_EXTERNAL_STORAGE permission doesn't get removed by other libraries.